### PR TITLE
chore: fix typedoc erroring

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
 	"out": "./docs/",
 	"readme": "./README.md",
 	"name": "@skyra/char",
-	"exclude": ["**/node_modules/**", "tests/**"],
+	"exclude": ["**/node_modules/**", "tests/**", "rollup.config.ts"],
 	"mode": "file",
 	"excludeExternals": true,
 	"excludePrivate": true,

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,8 +1,9 @@
 {
+	"inputFiles": ["./src"],
 	"out": "./docs/",
 	"readme": "./README.md",
 	"name": "@skyra/char",
-	"exclude": ["**/node_modules/**", "tests/**", "rollup.config.ts"],
+	"exclude": ["**/node_modules/**", "tests/**"],
 	"mode": "file",
 	"excludeExternals": true,
 	"excludePrivate": true,


### PR DESCRIPTION
Yes. It works.

No. There is no @types/rollup-plugin-cleaner